### PR TITLE
Better plurals support

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -102,10 +102,7 @@
     <string name="show_from_all_lists">Všechny seznamy</string>
     <string name="default_list_needed_warning">Nejprve zvolte výchozí seznam</string>
     <string name="reverted">Změny vráceny</string>
-    <string name="notecopied">Zkopírováno</string>
-    <string name="notecopied_msg">poznámek do schránky</string>
     <string name="deleted">Odstraněno</string>
-    <string name="items">poznámek</string>
     <string name="mode_choose">Výběr položek</string>
     
     <string name="permission_read_label">číst poznámky a seznamy</string>
@@ -126,32 +123,55 @@
     <string name="preferences_week_start_day_title" msgid="4619489296444901622">"Začátek týdne"</string>
     <string name="preferences_week_start_day_dialog" msgid="5181634128884089113">"Začátek týdne"</string>
     
-    <string name="mode_choose_single">vybrána jedna položka</string>
-    <string name="mode_choose_more">položky vybrány</string>
+    <string name="completed">Hotovo</string>
+    <string name="editor_details">Více</string>
+    <string name="security">Zabezpečení</string>
+    
+    <plurals name="notecopied_msg">
+        <item quantity="one">Zkopírována jedna položka.</item>
+        <item quantity="few">Zkopírovány %d položky.</item>
+        <item quantity="other">Zkopírováno %d položek.</item>
+    </plurals>
+    
+    <plurals name="notedeleted_msg">
+        <item quantity="one">Smazána jedna položka.</item>
+        <item quantity="few">Smazány %d položky.</item>
+        <item quantity="other">Smazáno %d položek.</item>
+    </plurals>
+    
+    <plurals name="mode_choose">
+        <item quantity="one">Vybrána jedna položka.</item>
+        <item quantity="few">Vybrány %d položky.</item>
+        <item quantity="other">Vybráno %d položek.</item>
+    </plurals>
+    
+    <string name="lock_note">Uzamknout</string>
+    <string name="unlock_note">Odemknout</string>
+    <string name="locked">Uzamčeno</string>
+    <string name="unlocked">Odemčeno</string>
+    <string name="password_required">Vyžadováno heslo</string>
+    <string name="select_account">Zvolte účet</string>
+    <string name="password">Heslo</string>
+    
+    <string name="password_set">Heslo nastaveno</string>
+    <string name="password_cleared">Heslo zrušeno</string>
+    <string name="passwords_dont_match">Hesla se neshodují</string>
+    <string name="enter_password">Zadejte heslo</string>
+    <string name="enter_new_password">Zadejte nové heslo</string>
+    <string name="confirm_new_password">Potvrďte nové heslo</string>
+    <string name="apply">Nastavit</string>
+    <string name="clear_password">Zrušit heslo</string>
+    
+    <string name="password_info">Po nastavení hesla bude potřeba pro uzamčené poznámky
+        zadat před jejich zobrazením heslo. Týká se to jenom textu poznámky, takže bude stále
+        nechráněn nadpis a datum. Nic se nešifruje, takže bude stále čitelná na webu GMail a
+        kalendáři. Pokud zapomenete heslo, stačí synchronizovat s účtem Google a přeinstalovat
+        aplikaci</string>
+    
+    <string name="sync_failed">Synchronizace selhala</string>
+    <string name="sync_login_failed">Přihlášení se nezdařilo, nelze se spojit s Google Tasks</string>
     
     <!-- Un-translated yet -->
-    <string name="lock_note">Lock note</string>
-    <string name="unlock_note">Unlock note</string>
-    <string name="locked">Locked</string>
-    <string name="unlocked">Unlocked</string>
-    <string name="password_required">Password required</string>
-    <string name="select_account">Select an account</string>
-    <string name="password">Password</string>
-    <string name="password_set">Password set</string>
-    <string name="password_cleared">Password cleared</string>
-    <string name="passwords_dont_match">Passwords do not match</string>
-    <string name="enter_password">Enter password</string>
-    <string name="enter_new_password">Enter new password</string>
-    <string name="confirm_new_password">Confirm new password</string>
-    <string name="apply">Apply</string>
-    <string name="clear_password">Clear password</string>
-    <string name="password_info">Setting a password will require you to input the password 
-        to show any locked notes. It will only protect the note-field so you still have unprotected
-        access to the title and due date. It does not encrypt the note in any way so it can still 
-        be viewed in Google mail/calendar. If you forget your password, sync with Google and
-        then reinstall the app.</string>
     <string name="about">About</string>
     
-    <string name="sync_failed">Sync failed</string>
-    <string name="sync_login_failed">Login failed, could not connect to Google Tasks</string>
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -90,7 +90,6 @@
     <string name="default_list_needed_warning">Seleccione primero una lista predeterminada</string>
     <string name="reverted">Cambios deshechos</string>
     <string name="notecopied">Copiado</string>
-    <string name="deleted">Eliminado</string>
     <string name="items">notas</string>
     <string name="permission_read_label">leer notas y listas</string>
     <string name="permission_read_desc">Permite a la aplicación leer sus notas y listas relacionadas.</string>
@@ -109,11 +108,23 @@
     <string name="preferences_week_start_day_title" msgid="4619489296444901622">"La semana empieza el"</string>
     <string name="preferences_week_start_day_dialog" msgid="5181634128884089113">"La semana empieza el"</string>
 
-    <string name="notecopied_msg">notas al portapapeles</string>
-    <string name="notecopied_msg_single">nota al portapapeles</string>
     <string name="mode_choose">Seleccionar elementos</string>
-    <string name="mode_choose_single">un elemento seleccionado</string>
-    <string name="mode_choose_more">elementos seleccionados</string>
+    
+    <plurals name="notecopied_msg">
+        <item quantity="one">Copiado de una nota.</item>
+        <item quantity="other">Copiado %d notas.</item>
+    </plurals>
+    
+    <plurals name="notedeleted_msg">
+        <item quantity="one">Eliminado de una nota.</item>
+        <item quantity="other">Elimiado %d notas.</item>
+    </plurals>
+    
+    <plurals name="mode_choose">
+        <item quantity="one">Elegida una nota.</item>
+        <item quantity="other">Seleccionados %d notas.</item>
+    </plurals>
+    
     <string name="lock_note">Bloquear nota</string>
     <string name="unlock_note">Desbloquear nota</string>
     <string name="locked">Bloqueada</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -112,11 +112,26 @@
     <string name="preferences_week_start_day_default" tools:ignore="MissingTranslation" >-1</string>
 
     <!-- Un-translated yet -->
-    <string name="notecopied_msg">notes to the clipboard</string>
-    <string name="notecopied_msg_single">note to the clipboard</string>
-    <string name="mode_choose">Select Items</string>
-    <string name="mode_choose_single">one item selected</string>
-    <string name="mode_choose_more">items selected</string>
+    
+    <!--
+        Use few if language need it. In English is the same.
+        <item quantity="few">Copied 2 notes.</item>
+    -->
+    <plurals name="notecopied_msg">
+        <item quantity="one">Copied one note.</item>
+        <item quantity="other">Copied %d notes.</item>
+    </plurals>
+    
+    <plurals name="notedeleted_msg">
+        <item quantity="one">Deleted one note.</item>
+        <item quantity="other">Deleted %d notes.</item>
+    </plurals>
+    
+    <plurals name="mode_choose">
+        <item quantity="one">Choosen one note.</item>
+        <item quantity="other">Choosen %d notes.</item>
+    </plurals>
+    
     <string name="lock_note">Lock note</string>
     <string name="unlock_note">Unlock note</string>
     <string name="locked">Locked</string>

--- a/src/com/nononsenseapps/notepad/NotesListFragment.java
+++ b/src/com/nononsenseapps/notepad/NotesListFragment.java
@@ -1243,18 +1243,9 @@ public class NotesListFragment extends NoNonsenseListFragment implements
 						buildTextToShare()));
 
 				int num = getListView().getCheckedItemCount();
-				int s;
 
-				if (num == 1)
-					s = R.string.notecopied_msg_single;
-				else
-					s = R.string.notecopied_msg;
-
-				Toast.makeText(
-						activity,
-						getString(R.string.notecopied) + num + " "
-								+ getString(s) + ".", Toast.LENGTH_SHORT)
-						.show();
+				Toast.makeText(activity,getResources().getQuantityString(R.plurals.notecopied_msg, num, num),
+				        Toast.LENGTH_SHORT).show();
 				mode.finish();
 				break;
 			case R.id.modal_delete:
@@ -1288,17 +1279,10 @@ public class NotesListFragment extends NoNonsenseListFragment implements
 				this.notesToDelete.remove(position);
 			}
 			final int checkedCount = getListView().getCheckedItemCount();
-			switch (checkedCount) {
-			case 0:
+			if (checkedCount == 0) {
 				mode.setSubtitle(null);
-				break;
-			case 1:
-				mode.setSubtitle(getString(R.string.mode_choose_single));
-				break;
-			default:
-				mode.setSubtitle(checkedCount + " "
-						+ getString(R.string.mode_choose_more));
-				break;
+			} else {
+			    mode.setSubtitle(getResources().getQuantityString(R.plurals.mode_choose, checkedCount, checkedCount));
 			}
 		}
 
@@ -1347,11 +1331,9 @@ public class NotesListFragment extends NoNonsenseListFragment implements
 				}
 				onDeleteListener.onModalDelete(notesToDelete);
 			}
-			Toast.makeText(
-					activity,
-					getString(R.string.deleted) + " " + num + " "
-							+ getString(R.string.items), Toast.LENGTH_SHORT)
-					.show();
+			
+			Toast.makeText(activity,getResources().getQuantityString(R.plurals.notedeleted_msg, num, num),
+			        Toast.LENGTH_SHORT).show();
 			mode.finish();
 		}
 


### PR DESCRIPTION
I removed that strange string concatenation and now is possible define plurals correctly for every language. Also updated Czech and Spanish translation. I hope that Spanish is correct, because I can't confirm it ;-).
