### PR TITLE
DateFormat L10N (Task Detail view)

### DIFF
--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -221,4 +221,6 @@ Use few if language need it. In English is the same.
 <string name="sync_full_force">強制的に全て同期</string>
 <string name="sync_full_force_info">ノート等の同期がおかしい場合のみチェックをONにしてください</string>
 
+<string name="dateformat_short">MM/dd(E)</string>
+<string name="dateformat_long">MM月dd日 (E曜日)</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -269,4 +269,6 @@
 	<string name="group_on_list_summary">Multiple notifications will be grouped together if they belong to the same list.</string>
 	<string name="more">more</string>
 	<string name="notifications">Notifications</string>
+	<string name="dateformat_short">E, d MMM</string>
+	<string name="dateformat_long">EEEE, d MMMM</string>
 </resources>

--- a/src/com/nononsenseapps/notepad/NotesEditorFragment.java
+++ b/src/com/nononsenseapps/notepad/NotesEditorFragment.java
@@ -18,15 +18,14 @@ package com.nononsenseapps.notepad;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 import java.util.TimeZone;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.LoaderManager;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
+import android.app.LoaderManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.ComponentName;
@@ -49,9 +48,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.format.DateFormat;
 import android.text.format.Time;
-import com.nononsenseapps.helpers.Log;
-import com.nononsenseapps.helpers.NotificationHelper;
-
 import android.util.TimeFormatException;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -78,6 +74,8 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.nononsenseapps.helpers.Log;
+import com.nononsenseapps.helpers.NotificationHelper;
 import com.nononsenseapps.helpers.UpdateNotifier;
 import com.nononsenseapps.notepad.PasswordDialog.ActionResult;
 import com.nononsenseapps.notepad.prefs.MainPrefs;
@@ -944,8 +942,13 @@ public class NotesEditorFragment extends Fragment implements TextWatcher,
 
 			dueDateSet = true;
 
+			String dateFormat = DATEFORMAT_FORMAT_SHORT;
+			if (getString(R.string.dateformat_short) != null) {
+				dateFormat = getString(R.string.dateformat_short);
+			}
+
 			note = note + getText(R.string.editor_due_date_hint) + ": "
-					+ DateFormat.format(DATEFORMAT_FORMAT_SHORT, c) + "\n";
+					+ DateFormat.format(dateFormat, c) + "\n";
 		}
 
 		if (mText != null)
@@ -1243,13 +1246,23 @@ public class NotesEditorFragment extends Fragment implements TextWatcher,
 				this.month = c.get(Calendar.MONTH);
 				this.day = c.get(Calendar.DAY_OF_MONTH);
 
-				mDueDate.setText(DateFormat.format(DATEFORMAT_FORMAT_LONG, c));
+				String dateFormatShort = DATEFORMAT_FORMAT_SHORT;
+				if (getString(R.string.dateformat_short) != null) {
+					dateFormatShort = getString(R.string.dateformat_short);
+				}
+
+				String dateFormatLong = DATEFORMAT_FORMAT_LONG;
+				if (getString(R.string.dateformat_long) != null) {
+					dateFormatLong = getString(R.string.dateformat_long);
+				}
+
+				mDueDate.setText(DateFormat.format(dateFormatLong, c));
 				Log.d("listproto", "Note has date: " + due);
 				Log.d("listproto",
 						"Note date shown as: "
-								+ DateFormat.format(DATEFORMAT_FORMAT_LONG, c));
+								+ DateFormat.format(dateFormatLong, c));
 				if (details != null)
-					details.setText(DateFormat.format(DATEFORMAT_FORMAT_SHORT,
+					details.setText(DateFormat.format(dateFormatShort,
 							c));
 			} catch (TimeFormatException e) {
 				noteDueDate.setToNow();
@@ -1387,10 +1400,20 @@ public class NotesEditorFragment extends Fragment implements TextWatcher,
 			noteDueDate.set(dayOfMonth, monthOfYear, year);
 			dueDateSet = true;
 
+			String dateFormatShort = DATEFORMAT_FORMAT_SHORT;
+			if (getString(R.string.dateformat_short) != null) {
+				dateFormatShort = getString(R.string.dateformat_short);
+			}
+
+			String dateFormatLong = DATEFORMAT_FORMAT_LONG;
+			if (getString(R.string.dateformat_long) != null) {
+				dateFormatLong = getString(R.string.dateformat_long);
+			}
+
 			final CharSequence shortTimeToShow = DateFormat.format(
-					DATEFORMAT_FORMAT_SHORT, c);
+					dateFormatShort, c);
 			final CharSequence longTimeToShow = DateFormat.format(
-					DATEFORMAT_FORMAT_LONG, c);
+					dateFormatLong, c);
 
 			if (activity != null) {
 				activity.runOnUiThread(new Runnable() {


### PR DESCRIPTION
When setting date to task, display date e.g. "Tuesday, 15 January".
But, in Japanese, unfortunately visible it e.g. "火曜日, 15 1月".
We expect it: "1月15日 火曜日".
This pull request will fix this problem.

![patch1](https://f.cloud.github.com/assets/867470/64929/8a2274b8-5e61-11e2-8b33-74540ecb1276.png)

I think my code is not smart, and I want to know better coding.
Please tell me this solution if my pull request is not better.
