### PR TITLE
fix for issue #336

### DIFF
--- a/app/src/main/java/com/nononsenseapps/notepad/ui/common/DialogDeleteList.java
+++ b/app/src/main/java/com/nononsenseapps/notepad/ui/common/DialogDeleteList.java
@@ -56,6 +56,9 @@ public class DialogDeleteList extends DialogConfirmBase {
 							null, null)) {
 				Toast.makeText(getActivity(), R.string.deleted,
 						Toast.LENGTH_SHORT).show();
+				NavigationDrawerFragment.NavigationDrawerCallbacks gCallbacks;
+				gCallbacks = (NavigationDrawerFragment.NavigationDrawerCallbacks) getActivity();
+				gCallbacks.openList(-2);
 			}
 		}
 		if (listener != null) {


### PR DESCRIPTION
One commit that adds three lines of code to dialogdeletelist.java, opens allist after the deletion.

fixes #336 